### PR TITLE
fix geometry reuse for unreachable features and add a "follow path" option to line generation

### DIFF
--- a/algs/OdMatrixFromLayersAsLines.py
+++ b/algs/OdMatrixFromLayersAsLines.py
@@ -80,7 +80,7 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
     DEFAULT_SPEED = 'DEFAULT_SPEED'
     TOLERANCE = 'TOLERANCE'
     OUTPUT = 'OUTPUT'
-    PATH_TYPE = 'PATH_TYPE'
+    MATRIX_GEOMETRY_TYPE = 'MATRIX_GEOMETRY_TYPE'
 
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'QNEAT3', 'icons', 'icon_matrix.svg'))
@@ -128,9 +128,9 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
                            self.tr('Fastest Path (time optimization)')
                            ]
 
-        self.PATH_TYPES = [self.tr('Straight  Line (as the crow flies)'),
-                           self.tr('Line Follows Path')
-                           ]
+        self.MATRIX_GEOMETRY_TYPES = [self.tr('Matrix geometry follows straight lines (as the crow flies)'),
+                                    self.tr('Matrix geometry follows routes')
+                                    ]
 
         self.ENTRY_COST_CALCULATION_METHODS = [self.tr('Ellipsoidal'),
                                        self.tr('Planar (only use with projected CRS)')]
@@ -169,9 +169,9 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
                                                  self.tr('Entry Cost calculation method'),
                                                  self.ENTRY_COST_CALCULATION_METHODS,
                                                  defaultValue=0))
-        params.append(QgsProcessingParameterEnum(self.PATH_TYPE,
-                                                 self.tr('Generated line type'),
-                                                 self.PATH_TYPES,
+        params.append(QgsProcessingParameterEnum(self.MATRIX_GEOMETRY_TYPE,
+                                                 self.tr('Generated matrix geometry style'),
+                                                 self.MATRIX_GEOMETRY_TYPES,
                                                  defaultValue=0))
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
                                                   self.tr('Direction field'),
@@ -219,7 +219,7 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
         to_points = self.parameterAsSource(parameters, self.TO_POINT_LAYER, context)
         to_id_field = self.parameterAsString(parameters, self.TO_ID_FIELD, context)
         strategy = self.parameterAsEnum(parameters, self.STRATEGY, context) #int
-        path_type =  self.parameterAsEnum(parameters, self.PATH_TYPE, context) #int
+        matrix_geometry_type =  self.parameterAsEnum(parameters, self.MATRIX_GEOMETRY_TYPE, context) #int
 
         entry_cost_calc_method = self.parameterAsEnum(parameters, self.ENTRY_COST_CALCULATION_METHOD, context) #int
         directionFieldName = self.parameterAsString(parameters, self.DIRECTION_FIELD, context) #str (empty if no field given)
@@ -290,7 +290,7 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
                     exit_cost = query_point.entry_cost
                     total_cost = network_cost + entry_cost + exit_cost
                     
-                    if path_type != 0:
+                    if matrix_geometry_type != 0:
                         this_tree=dijkstra_query[0]
                         idx_start = start_point.network_vertex_id
                         idx_end = query_point.network_vertex_id

--- a/algs/OdMatrixFromLayersAsLines.py
+++ b/algs/OdMatrixFromLayersAsLines.py
@@ -164,15 +164,14 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
                                                      self.STRATEGIES,
                                                      defaultValue=0))
 
-        self.addParameter(QgsProcessingParameterEnum(self.PATH_TYPE,
-                                                     self.tr('Generated line type'),
-                                                     self.PATH_TYPES,
-                                                     defaultValue=0))
-
         params = []
         params.append(QgsProcessingParameterEnum(self.ENTRY_COST_CALCULATION_METHOD,
                                                  self.tr('Entry Cost calculation method'),
                                                  self.ENTRY_COST_CALCULATION_METHODS,
+                                                 defaultValue=0))
+        params.append(QgsProcessingParameterEnum(self.PATH_TYPE,
+                                                 self.tr('Generated line type'),
+                                                 self.PATH_TYPES,
                                                  defaultValue=0))
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
                                                   self.tr('Direction field'),
@@ -291,11 +290,10 @@ class OdMatrixFromLayersAsLines(QgisAlgorithm):
                     exit_cost = query_point.entry_cost
                     total_cost = network_cost + entry_cost + exit_cost
                     
-                    this_tree=dijkstra_query[0]
-                    idx_start = start_point.network_vertex_id
-                    idx_end = query_point.network_vertex_id
-                    
                     if path_type != 0:
+                        this_tree=dijkstra_query[0]
+                        idx_start = start_point.network_vertex_id
+                        idx_end = query_point.network_vertex_id
                         # create a geometry following the complete path
                         route = [net.network.vertex(idx_end).point(),query_point.point_geom]
                         # Iterate the graph and add hops to route

--- a/algs/OdMatrixFromPointsAsLines.py
+++ b/algs/OdMatrixFromPointsAsLines.py
@@ -120,10 +120,12 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
             (self.tr('Both directions'), QgsVectorLayerDirector.DirectionBoth)])
 
         self.STRATEGIES = [self.tr('Shortest Path (distance optimization)'),
-                           self.tr('Fastest Path (time optimization)')]
+                           self.tr('Fastest Path (time optimization)')
+                           ]
 
         self.PATH_TYPES = [self.tr('Straight  Line (as the crow flies)'),
                            self.tr('Line Follows Path')
+                          ]
 
         self.ENTRY_COST_CALCULATION_METHODS = [self.tr('Ellipsoidal'),
                                        self.tr('Planar (only use with projected CRS)')]
@@ -264,7 +266,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                     sink.addFeature(feat, QgsFeatureSink.FastInsert)
                 else:
                     network_cost = dijkstra_query[1][query_point.network_vertex_id] 
-                    
+
                     if path_type != 0:
                         this_tree=dijkstra_query[0]
                         idx_start = start_point.network_vertex_id

--- a/algs/OdMatrixFromPointsAsLines.py
+++ b/algs/OdMatrixFromPointsAsLines.py
@@ -75,7 +75,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
     DEFAULT_SPEED = 'DEFAULT_SPEED'
     TOLERANCE = 'TOLERANCE'
     OUTPUT = 'OUTPUT'
-    PATH_TYPE = 'PATH_TYPE'
+    MATRIX_GEOMETRY_TYPE = 'MATRIX_GEOMETRY_TYPE'
 
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'QNEAT3', 'icons', 'icon_matrix.svg'))
@@ -123,9 +123,9 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                            self.tr('Fastest Path (time optimization)')
                            ]
 
-        self.PATH_TYPES = [self.tr('Straight  Line (as the crow flies)'),
-                           self.tr('Line Follows Path')
-                          ]
+        self.MATRIX_GEOMETRY_TYPES = [self.tr('Matrix geometry follows straight lines (as the crow flies)'),
+                                    self.tr('Matrix geometry follows routes')
+                                    ]
 
         self.ENTRY_COST_CALCULATION_METHODS = [self.tr('Ellipsoidal'),
                                        self.tr('Planar (only use with projected CRS)')]
@@ -151,9 +151,9 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                                                  self.tr('Entry Cost calculation method'),
                                                  self.ENTRY_COST_CALCULATION_METHODS,
                                                  defaultValue=0))
-        params.append(QgsProcessingParameterEnum(self.PATH_TYPE,
-                                                 self.tr('Generated line type'),
-                                                 self.PATH_TYPES,
+        params.append(QgsProcessingParameterEnum(self.MATRIX_GEOMETRY_TYPE,
+                                                 self.tr('Generated matrix geometry style'),
+                                                 self.MATRIX_GEOMETRY_TYPES,
                                                  defaultValue=0))
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
                                                   self.tr('Direction field'),
@@ -200,7 +200,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
         points = self.parameterAsSource(parameters, self.POINTS, context) #QgsProcessingFeatureSource
         id_field = self.parameterAsString(parameters, self.ID_FIELD, context) #str
         strategy = self.parameterAsEnum(parameters, self.STRATEGY, context) #int
-        path_type =  self.parameterAsEnum(parameters, self.PATH_TYPE, context) #int
+        matrix_geometry_type =  self.parameterAsEnum(parameters, self.MATRIX_GEOMETRY_TYPE, context) #int
 
         entry_cost_calc_method = self.parameterAsEnum(parameters, self.ENTRY_COST_CALCULATION_METHOD, context) #int
         directionFieldName = self.parameterAsString(parameters, self.DIRECTION_FIELD, context) #str (empty if no field given)
@@ -267,7 +267,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                 else:
                     network_cost = dijkstra_query[1][query_point.network_vertex_id] 
 
-                    if path_type != 0:
+                    if matrix_geometry_type != 0:
                         this_tree=dijkstra_query[0]
                         idx_start = start_point.network_vertex_id
                         idx_end = query_point.network_vertex_id

--- a/algs/OdMatrixFromPointsAsLines.py
+++ b/algs/OdMatrixFromPointsAsLines.py
@@ -75,6 +75,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
     DEFAULT_SPEED = 'DEFAULT_SPEED'
     TOLERANCE = 'TOLERANCE'
     OUTPUT = 'OUTPUT'
+    PATH_TYPE = 'PATH_TYPE'
 
     def icon(self):
         return QIcon(os.path.join(pluginPath, 'QNEAT3', 'icons', 'icon_matrix.svg'))
@@ -121,6 +122,9 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
         self.STRATEGIES = [self.tr('Shortest Path (distance optimization)'),
                            self.tr('Fastest Path (time optimization)')]
 
+        self.PATH_TYPES = [self.tr('Straight  Line (as the crow flies)'),
+                           self.tr('Line Follows Path')
+
         self.ENTRY_COST_CALCULATION_METHODS = [self.tr('Ellipsoidal'),
                                        self.tr('Planar (only use with projected CRS)')]
 
@@ -144,6 +148,10 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
         params.append(QgsProcessingParameterEnum(self.ENTRY_COST_CALCULATION_METHOD,
                                                  self.tr('Entry Cost calculation method'),
                                                  self.ENTRY_COST_CALCULATION_METHODS,
+                                                 defaultValue=0))
+        params.append(QgsProcessingParameterEnum(self.PATH_TYPE,
+                                                 self.tr('Generated line type'),
+                                                 self.PATH_TYPES,
                                                  defaultValue=0))
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
                                                   self.tr('Direction field'),
@@ -190,6 +198,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
         points = self.parameterAsSource(parameters, self.POINTS, context) #QgsProcessingFeatureSource
         id_field = self.parameterAsString(parameters, self.ID_FIELD, context) #str
         strategy = self.parameterAsEnum(parameters, self.STRATEGY, context) #int
+        path_type =  self.parameterAsEnum(parameters, self.PATH_TYPE, context) #int
 
         entry_cost_calc_method = self.parameterAsEnum(parameters, self.ENTRY_COST_CALCULATION_METHOD, context) #int
         directionFieldName = self.parameterAsString(parameters, self.DIRECTION_FIELD, context) #str (empty if no field given)
@@ -242,6 +251,7 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                     feat['network_cost'] = 0.0
                     feat['exit_cost'] = 0.0
                     feat['total_cost'] = 0.0
+                    feat.setGeometry(QgsGeometry())
                     sink.addFeature(feat, QgsFeatureSink.FastInsert)
                 elif dijkstra_query[0][query_point.network_vertex_id] == -1:
                     feat['origin_id'] = start_point.point_id
@@ -250,10 +260,27 @@ class OdMatrixFromPointsAsLines(QgisAlgorithm):
                     feat['network_cost'] = None
                     feat['exit_cost'] = None
                     feat['total_cost'] = None
+                    feat.setGeometry(QgsGeometry())
                     sink.addFeature(feat, QgsFeatureSink.FastInsert)
                 else:
-                    network_cost = dijkstra_query[1][query_point.network_vertex_id]
-                    feat.setGeometry(QgsGeometry.fromPolylineXY([start_point.point_geom, query_point.point_geom]))
+                    network_cost = dijkstra_query[1][query_point.network_vertex_id] 
+                    
+                    if path_type != 0:
+                        this_tree=dijkstra_query[0]
+                        idx_start = start_point.network_vertex_id
+                        idx_end = query_point.network_vertex_id
+                        # create a geometry following the complete path
+                        route = [net.network.vertex(idx_end).point(),query_point.point_geom]
+                        # Iterate the graph and add hops to route
+                        while idx_end != idx_start:
+                            idx_end = net.network.edge(this_tree[idx_end]).fromVertex()
+                            route.insert(0, net.network.vertex(idx_end).point())
+                        route.insert(0,start_point.point_geom)
+                    else:
+                        # geometry "as the crow flies"
+                        route = [start_point.point_geom, query_point.point_geom]
+                    
+                    feat.setGeometry(QgsGeometry.fromPolylineXY(route))
                     feat['origin_id'] = start_point.point_id
                     feat['destination_id'] = query_point.point_id
                     feat['entry_cost'] = start_point.entry_cost

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ qgisMinimumVersion=3.00
 qgisMaximumVersion=3.99
 description=QNEAT3 - QGIS Network Analysis Toolbox 3 
 about=The QNEAT3 (short for Qgis Network Analysis Toolbox 3) Plugin aims to provide sophisticated QGIS Processing-Toolbox algorithms in the field of network analysis. QNEAT3 is integrated in the QGIS3 Processing Framework. It offers algorithms that range from simple shortest path solving to more complex tasks like Iso-Area (aka service areas, accessibility polygons) and OD-Matrix (Origin-Destination-Matrix) computation. The usage of some Iso-Area algorithms require the installation of the matplotlib python library from OSGeo4W (see algorithm and help page for more information).
-version=1.0.4
+version=1.0.5
 author=Clemens Raffler
 email=clemens.raffler@gmail.com
 


### PR DESCRIPTION
Unreachable features would re-use the last geometry so multiple lines between source and origin would be generated. Now those links have an null geometry.
Also added the option for the generated lines in the layer to layer  and points as lines to follow the route path instead of the "as the crow flies" 